### PR TITLE
Marking as slow the things that actually are:

### DIFF
--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -1656,7 +1656,7 @@ def test_using_models():
             ' "ifnull"("weight", bql_predict(1, 42, 3, _rowid_, 0.9))' \
         ' FROM "t1";'
 
-def test_checkpoint():
+def test_checkpoint_slow():
     with test_core.t1() as (bdb, generator_id):
         bdb.execute('initialize 1 model for t1_cc')
         bdb.execute('analyze t1_cc for 10 iterations checkpoint 1 iteration'
@@ -1680,7 +1680,7 @@ def test_checkpoint():
         '''
         assert bdb.execute(sql, (generator_id,)).next()[0] == 1
 
-def test_infer_confidence():
+def test_infer_confidence_slow():
     with test_core.t1() as (bdb, _generator_id):
         bdb.execute('initialize 1 model for t1_cc')
         bdb.execute('analyze t1_cc for 1 iteration wait')

--- a/tests/test_column_dep.py
+++ b/tests/test_column_dep.py
@@ -25,7 +25,7 @@ from bayeslite.metamodels.crosscat import CrosscatMetamodel
 # Synthetic dataset (x,y,z,v,w) for the tests. Fixed seed is not used since
 # the tests should pass independently of the generated dataset.
 
-def test_complex_dependencies():
+def test_complex_dependencies_slow():
     # Parameterize number of rows in synthetic dataset.
     n_rows = 250
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -342,11 +342,11 @@ def test_example_analysis1(exname):
 # The multiprocessing engine has a large overhead, too much to try
 # every normal test with it, so we'll just run this one test to make
 # sure it doesn't crash and burn with ten models.
-def test_t1_mp_analysis_slow():
+def test_t1_mp_analysis():
     with analyzed_bayesdb_generator(t1_mp(), 10, 2):
         pass
 
-def test_t1_mp_analysis_time_deadline_slow():
+def test_t1_mp_analysis_time_deadline():
     with analyzed_bayesdb_generator(t1_mp(), 10, None, max_seconds=1):
         pass
 
@@ -360,10 +360,6 @@ def test_t1_analysis_time_deadline():
 
 def test_t1_analysis_iter_deadline_slow():
     with analyzed_bayesdb_generator(t1(), 10, 1, max_seconds=10):
-        pass
-
-def test_t1_mp_analysis_iter_deadline_slow():
-    with analyzed_bayesdb_generator(t1_mp(), 10, 1, max_seconds=10):
         pass
 
 @pytest.mark.parametrize('rowid,colno,confidence',

--- a/tests/test_geweke.py
+++ b/tests/test_geweke.py
@@ -47,7 +47,7 @@ def test_geweke_nig_normal():
         assert 0 < kl and kl < 10 # KL should be positive
         assert 0 < error and error < 10 # KL error estimate too
 
-def test_geweke_nig_normal_seriously():
+def test_geweke_nig_normal_seriously_slow():
     # Note: The actual assertions in this test and the next one were
     # dervied heuristically by inspecting a fuller (and costlier to
     # compute) tableau of values of geweke.geweke_kl and deciding the
@@ -71,7 +71,7 @@ class DoctoredNIGNormal(normal.NIGNormalMetamodel):
         # We actually had a bug that amounted to this
         return float(1.0/scale) / self.prng.gammavariate(shape, 1.0)
 
-def test_geweke_catches_nig_normal_bug():
+def test_geweke_catches_nig_normal_bug_slow():
     with bayeslite.bayesdb_open(builtin_metamodels=False) as bdb:
         bayeslite.bayesdb_register_metamodel(bdb, DoctoredNIGNormal(seed=1))
         cells = [(i,0) for i in range(4)]

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -29,7 +29,7 @@ dha_csv = os.path.join(root, 'dha.csv')
 dha_models = os.path.join(root, 'dha_models.pkl.gz')
 dha_codebook = os.path.join(root, 'dha_codebook.csv')
 
-def test_legacy_models():
+def test_legacy_models_slow():
     bdb = bayeslite.bayesdb_open(builtin_metamodels=False)
     cc = crosscat.LocalEngine.LocalEngine(seed=0)
     metamodel = CrosscatMetamodel(cc)


### PR DESCRIPTION
70.70s call     tests/test_geweke.py::test_geweke_nig_normal_seriously_slow
70.55s call     tests/test_geweke.py::test_geweke_catches_nig_normal_bug_slow
20.76s call     tests/test_bql.py::test_infer_confidence_slow
10.45s call     tests/test_legacy.py::test_legacy_models_slow
10.08s call     tests/test_core.py::test_t1_mp_analysis_iter_deadline_slow
10.06s call     tests/test_core.py::test_t1_analysis_iter_deadline_slow
5.50s call     tests/test_column_dep.py::test_complex_dependencies_slow
5.12s call     tests/test_bql.py::test_checkpoint_slow
2.93s call     tests/test_subsample.py::test_subsample
1.25s call     tests/test_bql.py::test_trivial_commands
1.20s call     tests/test_simulate.py::test_simulate_drawconstraint
1.09s call     tests/test_core.py::test_t1_mp_analysis_time_deadline
1.04s call     tests/test_core.py::test_t1_analysis_time_deadline
1.03s call     tests/test_bql.py::test_trivial_deadline
0.93s call     tests/test_bql.py::test_select_trivial
0.72s setup    shell/tests/test_shell.py::test_describe_generator
0.70s setup    shell/tests/test_shell.py::test_describe_models
0.70s setup    shell/tests/test_shell.py::test_describe_column_with_generator
0.69s call     tests/test_guess.py::test_guess_stattypes
0.66s call     shell/tests/test_shell.py::test_batch_file