### PR TITLE
Axch articulated tracing

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -68,6 +68,7 @@ contact bayesdb@mit.edu to participate in our research project.
 
 from bayeslite.bayesdb import BayesDB
 from bayeslite.bayesdb import bayesdb_open
+from bayeslite.bayesdb import IBayesDBTracer
 from bayeslite.codebook import bayesdb_load_codebook_csv_file
 from bayeslite.exception import BayesDBException
 from bayeslite.exception import BQLError
@@ -107,6 +108,7 @@ __all__ = [
     'bayesdb_register_metamodel',
     'bql_quote_name',
     'IBayesDBMetamodel',
+    'IBayesDBTracer',
     '__version__',
 ]
 

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -157,6 +157,9 @@ class BayesDB(object):
             bindings = ()
         if self.tracer:
             self.tracer(string, bindings)
+        return self._do_execute(string, bindings)
+
+    def _do_execute(self, string, bindings):
         phrases = parse.parse_bql_string(string)
         phrase = None
         try:

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -109,6 +109,10 @@ class BayesDB(object):
 
         `tracer` must have been previously established with
         :meth:`~BayesDB.trace`.
+
+        Any queries currently in progress will continue to be traced
+        until completion.
+
         """
         assert self.tracer == tracer
         self.tracer = None
@@ -138,6 +142,10 @@ class BayesDB(object):
 
         `tracer` must have been previously established with
         :meth:`~BayesDB.sql_trace`.
+
+        Any queries currently in progress will continue to be traced
+        until completion.
+
         """
         assert self.sql_tracer == tracer
         self.sql_tracer = None

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -85,20 +85,27 @@ class BayesDB(object):
         self.sqlite3 = None
 
     def trace(self, tracer):
-        """Call `tracer` for each BQL query executed.
+        """Trace execution of BQL queries.
 
-        `tracer` will be called with two arguments: the query to be
-        executed, as a string; and the sequence or dictionary of
+        For simple tracing, pass a function or arbitrary Python
+        callable as the `tracer`.  It will be called at the start of
+        execution of each BQL query, with two arguments: the query to
+        be executed, as a string; and the sequence or dictionary of
         bindings.
+
+        For articulated tracing, pass an instance of
+        :class:`~IBayesDBTracer`, whose methods will be called in the
+        pattern described in its documentation.
 
         Only one tracer can be established at a time.  To remove it,
         use :meth:`~BayesDB.untrace`.
+
         """
         assert self.tracer is None
         self.tracer = tracer
 
     def untrace(self, tracer):
-        """Stop calling `tracer` for each BQL query executed.
+        """Stop tracing execution of BQL queries.
 
         `tracer` must have been previously established with
         :meth:`~BayesDB.trace`.
@@ -107,20 +114,27 @@ class BayesDB(object):
         self.tracer = None
 
     def sql_trace(self, tracer):
-        """Call `tracer` for each SQL query executed.
+        """Trace execution of SQL queries.
 
-        `tracer` will be called with two arguments: the query to be
-        executed, as a string; and the sequence or dictionary of
+        For simple tracing, pass a function or arbitrary Python
+        callable as the `tracer`.  It will be called at the start of
+        execution of each SQL query, with two arguments: the query to
+        be executed, as a string; and the sequence or dictionary of
         bindings.
+
+        For articulated tracing, pass an instance of
+        :class:`~IBayesDBTracer`, whose methods will be called in the
+        pattern described in its documentation.
 
         Only one tracer can be established at a time.  To remove it,
         use :meth:`~BayesDB.sql_untrace`.
+
         """
         assert self.sql_tracer is None
         self.sql_tracer = tracer
 
     def sql_untrace(self, tracer):
-        """Stop calling `tracer` for each SQL query executed.
+        """Stop tracing execution of SQL queries.
 
         `tracer` must have been previously established with
         :meth:`~BayesDB.sql_trace`.

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -199,7 +199,7 @@ class BayesDB(object):
                 return TracingCursor(tracer, qid, cursor)
         except Exception as e:
             tracer.error(qid, e)
-            raise e
+            raise
 
     def _do_execute(self, string, bindings):
         phrases = parse.parse_bql_string(string)

--- a/src/metamodels/troll_rng.py
+++ b/src/metamodels/troll_rng.py
@@ -39,8 +39,8 @@ class TrollMetamodel(metamodel.IBayesDBMetamodel):
     def register(self, bdb):
         bdb.sql_execute('''
             INSERT INTO bayesdb_metamodel (name, version)
-                VALUES ('troll_rng', 1)
-        ''')
+                VALUES ('%s', 1)
+        ''' % self.name())
     def create_generator(self, bdb, table, schema, instantiate):
         instantiate(schema)
     def drop_generator(self, *args, **kwargs): pass

--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -24,6 +24,7 @@ import bayeslite.compiler as compiler
 import bayeslite.core as core
 import bayeslite.guess as guess
 import bayeslite.parse as parse
+import bayeslite.metamodels.troll_rng as troll
 
 import test_core
 import test_csv
@@ -1785,6 +1786,39 @@ def test_tracing_error_smoke():
             bdb.execute(q)
         assert tracer.start_calls == 1
         assert tracer.ready_calls == 0
+        assert tracer.error_calls == 1
+        assert tracer.finished_calls == 0
+        assert tracer.abandoned_calls == 0
+
+class Boom(Exception): pass
+class ErroneousMetamodel(troll.TrollMetamodel):
+    def __init__(self):
+        self.call_ct = 0
+    def name(self): return 'erroneous'
+    def row_column_predictive_probability(self, *_args, **_kwargs):
+        if self.call_ct > 10: # Wait to avoid raising during sqlite's prefetch
+            raise Boom()
+        self.call_ct += 1
+        return 0
+
+def test_tracing_execution_error_smoke():
+    with test_core.t1() as (bdb, _generator_id):
+        bayeslite.bayesdb_register_metamodel(bdb, ErroneousMetamodel())
+        bdb.execute('''
+            CREATE GENERATOR t1_err FOR t1 USING erroneous(age NUMERICAL)''')
+        q = 'ESTIMATE PREDICTIVE PROBABILITY OF age FROM t1_err'
+        tracer = MockTracerOneQuery(q)
+        bdb.trace(tracer)
+        cursor = bdb.execute(q)
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 1
+        assert tracer.error_calls == 0
+        assert tracer.finished_calls == 0
+        assert tracer.abandoned_calls == 0
+        with pytest.raises(sqlite3.OperationalError):
+            cursor.fetchall()
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 1
         assert tracer.error_calls == 1
         assert tracer.finished_calls == 0
         assert tracer.abandoned_calls == 0

--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -1726,35 +1726,36 @@ def test_empty_cursor():
         empty(bdb.execute('DROP GENERATOR t_cc'))
         empty(bdb.execute('DROP TABLE t'))
 
-def test_tracing_smoke():
-    q = 'select * from t1'
-    class MockTracer(bayeslite.IBayesDBTracer):
-        def __init__(self):
-            self.start_calls = 0
-            self.ready_calls = 0
-            self.error_calls = 0
-            self.finished_calls = 0
-            self.abandoned_calls = 0
-        def start(self, qid, query, bindings):
-            assert qid == 1
-            assert query == q
-            assert bindings == ()
-            self.start_calls += 1
-        def ready(self, qid, _cursor):
-            assert qid == 1
-            self.ready_calls += 1
-        def error(self, qid, _e):
-            assert qid == 1
-            self.error_calls += 1
-        def finished(self, qid):
-            assert qid == 1
-            self.finished_calls += 1
-        def abandoned(self, qid):
-            assert qid == 1
-            self.abandoned_calls += 1
+class MockTracerOneQuery(bayeslite.IBayesDBTracer):
+    def __init__(self, q):
+        self.q = q
+        self.start_calls = 0
+        self.ready_calls = 0
+        self.error_calls = 0
+        self.finished_calls = 0
+        self.abandoned_calls = 0
+    def start(self, qid, query, bindings):
+        assert qid == 1
+        assert query == self.q
+        assert bindings == ()
+        self.start_calls += 1
+    def ready(self, qid, _cursor):
+        assert qid == 1
+        self.ready_calls += 1
+    def error(self, qid, _e):
+        assert qid == 1
+        self.error_calls += 1
+    def finished(self, qid):
+        assert qid == 1
+        self.finished_calls += 1
+    def abandoned(self, qid):
+        assert qid == 1
+        self.abandoned_calls += 1
 
-    tracer = MockTracer()
+def test_tracing_smoke():
     with test_core.t1() as (bdb, _generator_id):
+        q = 'SELECT * FROM t1'
+        tracer = MockTracerOneQuery(q)
         bdb.trace(tracer)
         cursor = bdb.execute(q)
         assert tracer.start_calls == 1
@@ -1774,3 +1775,16 @@ def test_tracing_smoke():
         assert tracer.error_calls == 0
         assert tracer.finished_calls == 1
         assert tracer.abandoned_calls == 1
+
+def test_tracing_error_smoke():
+    with test_core.t1() as (bdb, _generator_id):
+        q = 'SELECT * FROM wrong'
+        tracer = MockTracerOneQuery(q)
+        bdb.trace(tracer)
+        with pytest.raises(sqlite3.OperationalError):
+            bdb.execute(q)
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 0
+        assert tracer.error_calls == 1
+        assert tracer.finished_calls == 0
+        assert tracer.abandoned_calls == 0

--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -1725,3 +1725,52 @@ def test_empty_cursor():
         empty(bdb.execute('INITIALIZE 1 MODEL FOR t_cc'))
         empty(bdb.execute('DROP GENERATOR t_cc'))
         empty(bdb.execute('DROP TABLE t'))
+
+def test_tracing_smoke():
+    q = 'select * from t1'
+    class MockTracer(bayeslite.IBayesDBTracer):
+        def __init__(self):
+            self.start_calls = 0
+            self.ready_calls = 0
+            self.error_calls = 0
+            self.finished_calls = 0
+            self.abandoned_calls = 0
+        def start(self, qid, query, bindings):
+            assert qid == 1
+            assert query == q
+            assert bindings == ()
+            self.start_calls += 1
+        def ready(self, qid, _cursor):
+            assert qid == 1
+            self.ready_calls += 1
+        def error(self, qid, _e):
+            assert qid == 1
+            self.error_calls += 1
+        def finished(self, qid):
+            assert qid == 1
+            self.finished_calls += 1
+        def abandoned(self, qid):
+            assert qid == 1
+            self.abandoned_calls += 1
+
+    tracer = MockTracer()
+    with test_core.t1() as (bdb, _generator_id):
+        bdb.trace(tracer)
+        cursor = bdb.execute(q)
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 1
+        assert tracer.error_calls == 0
+        assert tracer.finished_calls == 0
+        assert tracer.abandoned_calls == 0
+        cursor.fetchall()
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 1
+        assert tracer.error_calls == 0
+        assert tracer.finished_calls == 1
+        assert tracer.abandoned_calls == 0
+        del cursor
+        assert tracer.start_calls == 1
+        assert tracer.ready_calls == 1
+        assert tracer.error_calls == 0
+        assert tracer.finished_calls == 1
+        assert tracer.abandoned_calls == 1


### PR DESCRIPTION
Outstanding (potential) problems:
- Could add a test that an unread empty cursor calls finish early
- sql_execute of a query for which results are not expected may leave
  an open tracer for a while (until gc gets the cursor)
- {sql_,}execute of a query from which only one result is requested,
  without fetchall checking that only one is provided, same
- Do we want to permit or suppress multiple calls to "finished" on a
  tracer for a given query? e.g. from multiple calls to fetchone at
  the end, or multiple attempts to iterate?
- Code location: where should the tracing-related classes live?
  Fresh module?

For my part, I am satisfied with status quo, but amenable to changing it.
