### PR TITLE
Introduce exception-free ieee_exp

### DIFF
--- a/src/bqlfn.py
+++ b/src/bqlfn.py
@@ -26,6 +26,7 @@ from bayeslite.exception import BQLError
 from bayeslite.sqlite3_util import sqlite3_quote_name
 
 from bayeslite.util import casefold
+from bayeslite.util import ieee_exp
 from bayeslite.util import unique_indices
 
 def bayesdb_install_bql(db, cookie):
@@ -290,7 +291,7 @@ def bql_column_value_probability(bdb, generator_id, modelno, colno, value,
     targets = [(fake_row_id, colno, value)]
     r = metamodel.logpdf_joint(
         bdb, generator_id, targets, constraints, modelno)
-    return math.exp(r)
+    return ieee_exp(r)
 
 ### BayesDB row functions
 
@@ -315,7 +316,7 @@ def bql_row_column_predictive_probability(bdb, generator_id, modelno, rowid,
         return None
     r = metamodel.logpdf_joint(
         bdb, generator_id, [(rowid, colno, value)], [], modelno)
-    return math.exp(r)
+    return ieee_exp(r)
 
 ### Predict and simulate
 

--- a/src/util.py
+++ b/src/util.py
@@ -83,10 +83,18 @@ def logsumexp(array):
         return float('inf')
     elif m == -float('inf'):
         return -float('inf')
+    # This math.exp can't overflow b/c a - m is <= 0, so ieee_exp is
+    # the same.
     return m + math.log(sum(math.exp(a - m) for a in array))
 
 def logmeanexp(array):
     return logsumexp(array) - math.log(len(array))
+
+def ieee_exp(x):
+    try:
+        return math.exp(x)
+    except OverflowError:
+        return float("inf")
 
 def cursor_value(cursor):
     try:


### PR DESCRIPTION
 and use it in the bql functions that translate log probs into direct probs.

The only two other instances of math.exp in the code are the gamma
below and gamma above evaluations in math_util, whose intended behavior
I am not confident enough of to touch.  @riastradh-probcomp?