### PR TITLE
Fix #310, with test.

### DIFF
--- a/src/core.py
+++ b/src/core.py
@@ -452,4 +452,6 @@ def bayesdb_generator_fresh_row_id(bdb, generator_id):
     qt = sqlite3_quote_name(table_name)
     cursor = bdb.sql_execute('SELECT MAX(_rowid_) FROM %s' % (qt,))
     max_rowid = cursor_value(cursor)
+    if max_rowid is None:
+        max_rowid = 0
     return max_rowid + 1   # Synthesize a non-existent SQLite row id

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -579,3 +579,12 @@ def test_crosscat_constraints():
         assert engine._last_Y == [(3, 0, 1), (3, 2, 32)]
         bdb.execute('SIMULATE weight FROM t1_cc GIVEN age = 8 LIMIT 1').next()
         assert engine._last_Y == [(28, 1, 8)]
+
+def test_bayesdb_generator_fresh_row_id():
+    with bayesdb_generator(bayesdb(), 't1', 't1_cc', t1_schema, lambda x: 0,\
+            columns=['label CATEGORICAL', 'age NUMERICAL', 'weight NUMERICAL'])\
+            as (bdb, generator_id):
+        assert core.bayesdb_generator_fresh_row_id(bdb, generator_id) == 1
+        t1_data(bdb)
+        assert core.bayesdb_generator_fresh_row_id(bdb, generator_id) == \
+            len(t1_rows) + 1


### PR DESCRIPTION
If the table has no rows, then cursor_value(cursor) returns None
and we cannot concat None + int.
cursor_value(cursor)sqlite3_last_insert_rowid API call returns zero
if nothing has ever been inserted into the table, thus making zero
a de-facto "invalid" row ID.