### PR TITLE
Switch bayeslite from Python sqlite3 module to apsw.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -71,18 +71,18 @@ To tag a new version:
 Use SQL/BQL parameters to pass strings and other values into SQL/BQL.
 DO NOT use format strings.
 
-DO:     db.execute('UPDATE foo SET x = ? WHERE id = ?', (x, id))
-DON'T:  db.execute("UPDATE foo SET x = '%s' WHERE id = %d" % (x, id))
-DON'T:  db.execute("UPDATE foo SET x = '{}' WHERE id = {}".format(x, id))
+DO:     cursor.execute('UPDATE foo SET x = ? WHERE id = ?', (x, id))
+DON'T:  cursor.execute("UPDATE foo SET x = '%s' WHERE id = %d" % (x, id))
+DON'T:  cursor.execute("UPDATE foo SET x = '{}' WHERE id = {}".format(x, id))
 
-DO:     db.execute('SELECT x, y FROM t WHERE z = ?', (z,))
-DON'T:  db.execute('SELECT x, y FROM t WHERE z = ?', z)
-DON'T:  db.execute('SELECT x, y FROM t WHERE z = {}'.format(z))
+DO:     cursor.execute('SELECT x, y FROM t WHERE z = ?', (z,))
+DON'T:  cursor.execute('SELECT x, y FROM t WHERE z = ?', z)
+DON'T:  cursor.execute('SELECT x, y FROM t WHERE z = {}'.format(z))
 
 Prefer named parameters if the query has more than one parameter and
 covers multiple lines:
 
-        cursor = db.execute('''
+        cursor = db.cursor().execute('''
             SELECT COUNT(*)
                 FROM bayesdb_generator AS g, bayesdb_column AS c
                 WHERE g.id = :generator_id
@@ -101,10 +101,10 @@ reusing subroutines that already do it, such as in bayeslite.core.
 DO:     from bayeslite import bql_quote_name
         qt = bql_quote_name(table)
         qc = bql_quote_name(column)
-        db.execute('SELECT %s FROM %s WHERE x = ?' % (qc, qt), (x,))
+        cursor.execute('SELECT %s FROM %s WHERE x = ?' % (qc, qt), (x,))
 
-DON'T:  db.execute('SELECT %s FROM %s WHERE x = ?' % (column, table), (x,))
-DON'T:  db.execute('SELECT %s FROM %s WHERE x = %d' % (qc, qt, x))
+DON'T:  cursor.execute('SELECT %s FROM %s WHERE x = ?' % (column, table), (x,))
+DON'T:  cursor.execute('SELECT %s FROM %s WHERE x = %d' % (qc, qt, x))
 
 * Randomization
 
@@ -145,9 +145,9 @@ When issuing an UPDATE command to sqlite3, if you can count the number
 of rows it should affect, do so and assert that it affected that many
 rows:
 
-    total_changes = bdb.sqlite3.total_changes
+    total_changes = bdb._sqlite3.totalchanges()
     bdb.sql_execute('UPDATE ...', (...))
-    assert bdb.sqlite3.total_changes - total_changes == 1
+    assert bdb._sqlite3.totalchanges() - total_changes == 1
 
 XXX Should not use bdb.sqlite3 explicitly here.
 XXX Not every use is so marked.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Bayeslite depends on:
 - [Crosscat](https://github.com/probcomp/crosscat),
   a general-purpose nonparametric Bayesian population model which
   serves as a default in the absence of a domain-specific model.
+- [apsw](https://rogerbinns.github.io/apsw/), a sqlite3 wrapper for
+  Python more articulated than the builtin sqlite3 module
 - [numpy](http://www.numpy.org), a library of vectorized numerical
   algorithms
 - [requests](http://www.python-requests.org/), an HTTP/HTTPS library,

--- a/setup.py
+++ b/setup.py
@@ -201,6 +201,7 @@ setup(
     author_email='bayesdb@mit.edu',
     license='Apache License, Version 2.0',
     install_requires=[
+        'apsw>=3.7.17',
         'crosscat>=0.1.37',
         'numpy',
         'requests',

--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ setup(
     author_email='bayesdb@mit.edu',
     license='Apache License, Version 2.0',
     install_requires=[
-        'apsw>=3.7.17',
+        'bayeslite-apsw>=3.7.17',
         'crosscat>=0.1.37',
         'numpy',
         'requests',

--- a/shell/src/core.py
+++ b/shell/src/core.py
@@ -15,9 +15,9 @@
 #   limitations under the License.
 
 import StringIO
+import apsw
 import cmd
 import traceback
-import sqlite3
 import sys
 
 import bayeslite
@@ -333,7 +333,7 @@ class Shell(cmd.Cmd):
         '''
         try:
             pretty.pp_cursor(self.stdout, self._bdb.sql_execute(line))
-        except sqlite3.Error as e:
+        except apsw.Error as e:
             self.stdout.write('%s\n' % (e,))
         except Exception as e:
             self.stdout.write(traceback.format_exc())

--- a/shell/tests/test_shell.py
+++ b/shell/tests/test_shell.py
@@ -247,7 +247,7 @@ def test_sql(spawntable):
     c.expect_prompt()
     c.sendexpectcmd('.sql select * from foo')
     c.expect_lines([
-        'no such table: foo'
+        'SQLError: no such table: foo'
     ])
     c.expect_prompt()
 

--- a/shell/tests/test_shell.py
+++ b/shell/tests/test_shell.py
@@ -275,10 +275,19 @@ def test_describe_generator(spawntablegen):
 
 def test_describe_models(spawntablegen):
     table, gen, c = spawntablegen
-    models_output = [
-        'modelno | iterations',
-        '--------+-----------',
-    ]
+    # XXX apsw bug: There is no way to discover the description of a
+    # cursor that yields no rows.  The best we can do without failing
+    # is to assume that such a cursor has no columns either.  This is
+    # a regression from the Python sqlite3 module.  When we find a way
+    # to fix that, change the sense of this conditional (and eliminate
+    # it).
+    if True:
+        models_output = []
+    else:
+        models_output = [
+            'modelno | iterations',
+            '--------+-----------',
+        ]
     c.sendexpectcmd('.describe models %s' % (table,))
     c.expect_lines(['No such generator: %s' % (repr(table),),])
     c.expect_prompt()

--- a/src/bqlfn.py
+++ b/src/bqlfn.py
@@ -31,8 +31,7 @@ from bayeslite.util import unique_indices
 
 def bayesdb_install_bql(db, cookie):
     def function(name, nargs, fn):
-        db.create_function(name, nargs,
-            lambda *args: bayesdb_bql(fn, cookie, *args))
+        db.createscalarfunction(name, (lambda *args: fn(cookie, *args)), nargs)
     function("bql_column_correlation", 3, bql_column_correlation)
     function("bql_column_correlation_pvalue", 3, bql_column_correlation_pvalue)
     function("bql_column_dependence_probability", 4,
@@ -45,17 +44,6 @@ def bayesdb_install_bql(db, cookie):
     function("bql_predict", 5, bql_predict)
     function("bql_predict_confidence", 4, bql_predict_confidence)
     function("bql_json_get", 2, bql_json_get)
-
-# XXX XXX XXX Temporary debugging kludge!
-import sys
-import traceback
-
-def bayesdb_bql(fn, cookie, *args):
-    try:
-        return fn(cookie, *args)
-    except Exception as e:
-        print >>sys.stderr, traceback.format_exc()
-        raise e
 
 ### BayesDB column functions
 

--- a/src/codebook.py
+++ b/src/codebook.py
@@ -73,11 +73,11 @@ def bayesdb_load_codebook_csv_file(bdb, table, pathname):
                     SET shortname = :shortname, description = :description
                     WHERE tabname = :table AND colno = :colno
             '''
-            total_changes = bdb.sqlite3.total_changes
+            total_changes = bdb._sqlite3.totalchanges()
             bdb.sql_execute(sql, {
                 'shortname': shortname,
                 'description': description,
                 'table': table,
                 'colno': colno,
             })
-            assert bdb.sqlite3.total_changes - total_changes == 1
+            assert bdb._sqlite3.totalchanges() - total_changes == 1

--- a/src/sessions.py
+++ b/src/sessions.py
@@ -203,14 +203,19 @@ class SessionOrchestrator(object):
             SELECT version FROM bayesdb_session
                 WHERE id = ?
         ''', (session_id,)))
-        entries = self._sql('''
+        cursor = self._sql('''
             SELECT * FROM bayesdb_session_entries
                 WHERE session_id = ?
                 ORDER BY start_time DESC
         ''', (session_id,))
+        # XXX Get the description first because apsw cursors, for
+        # whatever reason, don't let you get the description after
+        # you've gotten all the results.
+        fields = [d[0] for d in cursor.description]
+        entries = cursor.fetchall()
         session = {
-            'entries': entries.fetchall(),
-            'fields': [d[0] for d in entries.description],
+            'entries': entries,
+            'fields': fields,
             'version': version,
         }
         return json.dumps(session, sort_keys=True)

--- a/src/sessions.py
+++ b/src/sessions.py
@@ -119,11 +119,11 @@ class SessionOrchestrator(object):
             print msg
 
     def _sql(self, query, bindings=None):
-        # Go through bdb.sqlite3.execute instead of bdb.sql_execute to
-        # avoid hitting the tracer.
+        # Go through bdb._sqlite3.cursor().execute instead of
+        # bdb.sql_execute to avoid hitting the tracer.
         if bindings == None:
             bindings = ()
-        return self.bdb.sqlite3.execute(query, bindings)
+        return self.bdb._sqlite3.cursor().execute(query, bindings)
 
     def _add_entry(self, qid, type, query, bindings):
         '''Save a session entry into the database. The entry is initially in

--- a/src/sqlite3_util.py
+++ b/src/sqlite3_util.py
@@ -37,15 +37,15 @@ def sqlite3_transaction(db):
     Transactions may not be nested.  Use savepoints if you want a
     nestable analogue to transactions.
     """
-    db.execute("BEGIN")
+    db.cursor().execute("BEGIN")
     ok = False
     try:
         yield
-        db.execute("COMMIT")
+        db.cursor().execute("COMMIT")
         ok = True
     finally:
         if not ok:
-            db.execute("ROLLBACK")
+            db.cursor().execute("ROLLBACK")
 
 @contextlib.contextmanager
 def sqlite3_savepoint(db):
@@ -60,26 +60,26 @@ def sqlite3_savepoint(db):
     # as is.  So for either success or failure we must release the
     # savepoint explicitly.
     savepoint = binascii.b2a_hex(os.urandom(32))
-    db.execute("SAVEPOINT x%s" % (savepoint,))
+    db.cursor().execute("SAVEPOINT x%s" % (savepoint,))
     ok = False
     try:
         yield
         ok = True
     finally:
         if not ok:
-            db.execute("ROLLBACK TO x%s" % (savepoint,))
-        db.execute("RELEASE x%s" % (savepoint,))
+            db.cursor().execute("ROLLBACK TO x%s" % (savepoint,))
+        db.cursor().execute("RELEASE x%s" % (savepoint,))
 
 @contextlib.contextmanager
 def sqlite3_savepoint_rollback(db):
     """Savepoint context manager that always rolls back."""
     savepoint = binascii.b2a_hex(os.urandom(32))
-    db.execute("SAVEPOINT x%s" % (savepoint,))
+    db.cursor().execute("SAVEPOINT x%s" % (savepoint,))
     try:
         yield
     finally:
-        db.execute("ROLLBACK TO x%s" % (savepoint,))
-        db.execute("RELEASE x%s" % (savepoint,))
+        db.cursor().execute("ROLLBACK TO x%s" % (savepoint,))
+        db.cursor().execute("RELEASE x%s" % (savepoint,))
 
 def sqlite3_exec_1(db, query, *args):
     """Execute a query returning a 1x1 table, and return its one value.
@@ -87,7 +87,7 @@ def sqlite3_exec_1(db, query, *args):
     Do not call this if you cannot guarantee the result is a 1x1
     table.  Beware passing user-controlled input in here.
     """
-    cursor = db.execute(query, *args)
+    cursor = db.cursor().execute(query, *args)
     row = cursor.fetchone()
     assert row
     assert len(row) == 1

--- a/src/txn.py
+++ b/src/txn.py
@@ -36,7 +36,7 @@ def bayesdb_caching(bdb):
 def bayesdb_savepoint(bdb):
     bayesdb_txn_push(bdb)
     try:
-        with sqlite3_savepoint(bdb.sqlite3):
+        with sqlite3_savepoint(bdb._sqlite3):
             yield
     finally:
         bayesdb_txn_pop(bdb)
@@ -45,7 +45,7 @@ def bayesdb_savepoint(bdb):
 def bayesdb_savepoint_rollback(bdb):
     bayesdb_txn_push(bdb)
     try:
-        with sqlite3_savepoint_rollback(bdb.sqlite3):
+        with sqlite3_savepoint_rollback(bdb._sqlite3):
             yield
     finally:
         bayesdb_txn_pop(bdb)
@@ -57,7 +57,7 @@ def bayesdb_transaction(bdb):
     bayesdb_txn_init(bdb)
     bdb.txn_depth = 1
     try:
-        with sqlite3_transaction(bdb.sqlite3):
+        with sqlite3_transaction(bdb._sqlite3):
             yield
     finally:
         assert bdb.txn_depth == 1

--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -1873,7 +1873,7 @@ def test_tracing_execution_error_smoke():
         assert tracer.error_calls == 0
         assert tracer.finished_calls == 0
         assert tracer.abandoned_calls == 0
-        with pytest.raises(apsw.SQLError):
+        with pytest.raises(Boom):
             cursor.fetchall()
         assert tracer.start_calls == 1
         assert tracer.ready_calls == 1

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -149,17 +149,7 @@ def bayesdb_generator(mkbdb, tab, gen, table_schema, data, columns,
         qmm = bql_quote_name(metamodel_name)
         bdb.execute('CREATE GENERATOR %s FOR %s USING %s(%s)' %
             (qg, qt, qmm, ','.join(columns)))
-        sql = 'SELECT id FROM bayesdb_generator WHERE name = ?'
-        cursor = bdb.sql_execute(sql, (gen,))
-        try:
-            row = cursor.next()
-        except StopIteration:
-            assert False, 'Generator didn\'t make it!'
-        else:
-            assert len(row) == 1
-            assert isinstance(row[0], int)
-            generator_id = row[0]
-            yield bdb, generator_id
+        yield bdb, core.bayesdb_get_generator(bdb, gen)
 
 @contextlib.contextmanager
 def analyzed_bayesdb_generator(mkbdb, nmodels, nsteps, max_seconds=None):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,10 +14,10 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import apsw
 import contextlib
 import itertools
 import pytest
-import sqlite3
 import tempfile
 
 import crosscat.LocalEngine
@@ -79,8 +79,8 @@ def test_openclose():
 def test_bad_db_application_id():
     with tempfile.NamedTemporaryFile(prefix='bayeslite') as f:
         with sqlite3_connection(f.name) as db:
-            db.execute('PRAGMA application_id = 42')
-            db.execute('PRAGMA user_version = 3')
+            db.cursor().execute('PRAGMA application_id = 42')
+            db.cursor().execute('PRAGMA user_version = 3')
         with pytest.raises(IOError):
             with bayesdb(pathname=f.name):
                 pass
@@ -90,8 +90,8 @@ def test_bad_db_user_version():
     # the sqlite3 database connection in?
     with tempfile.NamedTemporaryFile(prefix='bayeslite') as f:
         with sqlite3_connection(f.name) as db:
-            db.execute('PRAGMA application_id = 1113146434')
-            db.execute('PRAGMA user_version = 42')
+            db.cursor().execute('PRAGMA application_id = 1113146434')
+            db.cursor().execute('PRAGMA user_version = 42')
         with pytest.raises(IOError):
             with bayesdb(pathname=f.name):
                 pass
@@ -193,7 +193,7 @@ def test_casefold_colname():
             pass
         return bayesdb_generator(bayesdb(), tname, gname, schema, data, *args,
             **kwargs)
-    with pytest.raises(sqlite3.OperationalError):
+    with pytest.raises(apsw.SQLError):
         with t('t', 't_cc', 'create table t(x, X)', []):
             pass
     with pytest.raises(bayeslite.BQLError):

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -15,9 +15,9 @@
 #   limitations under the License.
 
 import StringIO
+import apsw
 import contextlib
 import pytest
-import sqlite3
 import tempfile
 
 import bayeslite
@@ -121,9 +121,9 @@ def test_csv_import_schema():
         # compatibility with MySQL idiocy or something, SQLite treats
         # double-quotes as single-quotes if the alternative would be
         # an error.
-        with pytest.raises(sqlite3.OperationalError):
+        with pytest.raises(apsw.SQLError):
             bdb.execute('select idontexist from employees')
-            raise sqlite3.OperationalError('BQL compiler is broken;'
+            raise apsw.SQLError('BQL compiler is broken;'
                 ' a.k.a. sqlite3 is stupid.')
         bdb.execute('''
             CREATE GENERATOR employees_cc FOR employees USING crosscat(

--- a/tests/test_read_pandas.py
+++ b/tests/test_read_pandas.py
@@ -14,9 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import apsw
 import pandas
 import pytest
-import sqlite3
 
 from bayeslite import bayesdb_open
 from bayeslite import bql_quote_name
@@ -40,7 +40,7 @@ def do_test(bdb, t, df, index=None):
             index=index)
     assert 4 == bdb.execute(countem).fetchvalue()
 
-    with pytest.raises(sqlite3.IntegrityError):
+    with pytest.raises(apsw.ConstraintError):
         bayesdb_read_pandas_df(bdb, t, df, create=True, ifnotexists=True,
             index=index)
     assert 4 == bdb.execute(countem).fetchvalue()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -222,7 +222,7 @@ def test_sessions_error_metamodel():
         cursor = bdb.execute('''
             ESTIMATE PREDICTIVE PROBABILITY OF age FROM t1_err
         ''')
-        with pytest.raises(apsw.SQLError):
+        with pytest.raises(Boom):
             cursor.fetchall()
         #tr._start_new_session()
         assert tr._check_error_entries(tr.session_id) > 0

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -14,9 +14,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import apsw
 import json
 import pytest
-import sqlite3
 
 from collections import namedtuple
 
@@ -168,7 +168,7 @@ def _nonexistent_table_helper(executor, tr):
     try:
         executor(query)
         assert False
-    except sqlite3.OperationalError:
+    except apsw.SQLError:
         #tr._start_new_session()
         assert tr._check_error_entries(tr.session_id) > 0
 
@@ -222,7 +222,7 @@ def test_sessions_error_metamodel():
         cursor = bdb.execute('''
             ESTIMATE PREDICTIVE PROBABILITY OF age FROM t1_err
         ''')
-        with pytest.raises(sqlite3.OperationalError):
+        with pytest.raises(apsw.SQLError):
             cursor.fetchall()
         #tr._start_new_session()
         assert tr._check_error_entries(tr.session_id) > 0
@@ -250,7 +250,7 @@ def test_sessions_send_data__ci_network():
 
 def test_error():
     (bdb, tr) = make_bdb_with_sessions()
-    with pytest.raises(sqlite3.OperationalError):
+    with pytest.raises(apsw.SQLError):
         bdb.execute('select x from nonexistent_table')
     assert 1 == bdb.sql_execute('''
             SELECT COUNT(*) FROM bayesdb_session_entries


### PR DESCRIPTION
This resolves issues #92 and #315, and unblocks a host of others.

Caveats:

- `bdb.[sql_]execute(q).description` is broken when q returns zero results -- in particular, it will always return an empty list in that case, even if q might at other times yield rows with a nonzero number of columns, e.g. `select * from t` when t is empty now.
- `bdb.sqlite3` does not exist any more.  Code that was using it should be fixed, and/or have issues filed for the missing functionality.  (It has been renamed to `bdb._sqlite3` in case we really really still need to use it for now.)
- I have not tested it with bdbcontrib yet.