### PR TITLE
Raise an error when initializing models without columns

### DIFF
--- a/src/metamodels/crosscat.py
+++ b/src/metamodels/crosscat.py
@@ -279,6 +279,9 @@ class CrosscatMetamodel(metamodel.IBayesDBMetamodel):
                 ORDER BY c.colno ASC
         '''
         columns = bdb.sql_execute(columns_sql, (generator_id,)).fetchall()
+        if not columns:
+            raise BQLError(bdb,
+                'No columns found for generator (id = %r)' % generator_id)
         colnames = [name for name, _colno in columns]
         qcns = map(sqlite3_quote_name, colnames)
         cursor = bdb.sql_execute('''


### PR DESCRIPTION
Currently, if you CREATE GENERATOR in such a way that no columns are created, then INITIALIZE MODELS will give a syntax error instead of giving a useful error.