### PR TITLE
Remove xfails.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -392,7 +392,10 @@ def test_t1_predict(rowid, colno, confidence):
         for numpred in range(3)])
 def test_t1_simulate(colnos, constraints, numpredictions):
     if len(colnos) == 0:
-        pytest.xfail("Crosscat can't simulate zero columns.")
+        # No need to try this or confirm it fails gracefully --
+        # nothing should be trying it anyway, and bayeslite_simulate
+        # is not exposed to users of the bayeslite API.
+        return
     with analyzed_bayesdb_generator(t1(), 1, 1) as (bdb, generator_id):
         if constraints is not None:
             rowid = 1           # XXX Avoid hard-coding this.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -347,8 +347,6 @@ def test_example_analysis0(exname):
 
 @pytest.mark.parametrize('exname', examples.keys())
 def test_example_analysis1(exname):
-    if exname == 't0':
-        pytest.xfail("Crosscat can't handle a table with only one column.")
     with analyzed_bayesdb_generator(examples[exname](), 1, 1):
         pass
 


### PR DESCRIPTION
These commits remove the last xfails that I lazily put in at the very beginning of development when iterating fast and trying to avoid debugging Crosscat.  From this I learned that pytest.xfail does not do what I expected, which is to *confirm* that the test fails and fail if it doesn't.  Pooh.  (This is different from `with pytest.raises(Exception):` because I'm not testing for a specific exception as part of the test's intent, just annotating that the test is broken.)

Fixes <https://github.com/probcomp/bayeslite/issues/319>.