### PR TITLE
Implement @stochastic test decorator to report and vary seeds for controlled test nondeterminism.

### DIFF
--- a/HACKING
+++ b/HACKING
@@ -123,6 +123,33 @@ can control, via the normal Python API and the bayeslite shell.  Any
 actual nondeterminism should be clearly labelled as such, e.g. a
 future shell command to choose a seed from /dev/urandom.
 
+To write nondeterministic tests that explore an intentionally
+unpredictable source of inputs, instead of testing exactly the same
+input every time, write a deterministic function of a 32-byte seed and
+use the @stochastic decorator to vary it:
+
+    from stochastic import stochastic
+
+    @stochastic(max_runs=4, min_passes=2)
+    def test_quagga(seed):
+        frobnicate(seed)
+
+This defines test_quagga to be a function that accepts an *optional*
+seed argument.  If you call it with zero arguments, then it will call
+frobnicate up to four times, and if it does not pass twice, it will
+raise a StochasticError that includes (a) the last exception with
+which frobnicate failed and (b) the last seed with which frobnicate
+failed.
+
+You can then retry using exactly the same seed by calling test_quagga
+manually with the seed as its argument:
+
+    >>> test_quagga()
+    StochasticError: [seed 434529bf3e5a16930701b55c39a90acfcd115ba0cada99f5af5448f3b96923dd]
+    ZigException: something set us up the bomb
+    >>> test_quagga('434529bf3e5a16930701b55c39a90acfcd115ba0cada99f5af5448f3b96923dd'.decode('hex'))
+    ZigException: something set us up the bomb
+
 * Python coding style
 
 Generally follow PEP 8, with these exceptions:

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,6 @@ setup(
         'setuptools', # For parse_version in src/remote.py
     ],
     tests_require=[
-        'flaky',
         'pandas',
         'pexpect',
         'pytest',

--- a/tests/stochastic.py
+++ b/tests/stochastic.py
@@ -23,7 +23,7 @@ class StochasticError(Exception):
         self.exctype = exctype
         self.excvalue = excvalue
     def __str__(self):
-        hexseed = ''.join('%02x' % (ord(b),) for b in self.seed)
+        hexseed = self.seed.encode('hex')
         if hasattr(self.exctype, '__name__'):
             typename = self.exctype.__name__
         else:

--- a/tests/stochastic.py
+++ b/tests/stochastic.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+#   Copyright (c) 2010-2016, MIT Probabilistic Computing Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import os
+import sys
+
+class StochasticError(Exception):
+    def __init__(self, seed, exctype, excvalue):
+        self.seed = seed
+        self.exctype = exctype
+        self.excvalue = excvalue
+    def __str__(self):
+        hexseed = ''.join('%02x' % (ord(b),) for b in self.seed)
+        if hasattr(self.exctype, '__name__'):
+            typename = self.exctype.__name__
+        else:
+            typename = repr(self.exctype)
+        return '[seed %s]\n%s: %s' % (hexseed, typename, self.excvalue)
+
+def stochastic(max_runs, min_passes):
+    assert 0 < max_runs
+    assert min_passes < max_runs
+    def wrap(f):
+        def f_(seed=None):
+            if seed is not None:
+                return f(seed)
+            npasses = 0
+            last_seed = None
+            last_exc_info = None
+            for i in xrange(max_runs):
+                seed = os.urandom(32)
+                try:
+                    value = f(seed)
+                except:
+                    last_seed = seed
+                    last_exc_info = sys.exc_info()
+                else:
+                    npasses += 1
+                    if min_passes <= npasses:
+                        return value
+            t, v, tb = last_exc_info
+            raise StochasticError, StochasticError(last_seed, t, v), tb
+        return f_
+    return wrap

--- a/tests/stochastic.py
+++ b/tests/stochastic.py
@@ -32,7 +32,7 @@ class StochasticError(Exception):
 
 def stochastic(max_runs, min_passes):
     assert 0 < max_runs
-    assert min_passes < max_runs
+    assert min_passes <= max_runs
     def wrap(f):
         def f_(seed=None):
             if seed is not None:

--- a/tests/test_bql.py
+++ b/tests/test_bql.py
@@ -29,6 +29,8 @@ import bayeslite.metamodels.troll_rng as troll
 import test_core
 import test_csv
 
+from stochastic import stochastic
+
 def bql2sql(string, setup=None):
     with test_core.t1() as (bdb, _table_id):
         if setup is not None:
@@ -72,10 +74,9 @@ def empty(cursor):
     with pytest.raises(StopIteration):
         cursor.next()
 
-from flaky import flaky
-@flaky(max_runs=2, min_passes=1)
-def test_conditional_probability():
-    with test_core.t1() as (bdb, _generator_id):
+@stochastic(max_runs=2, min_passes=1)
+def test_conditional_probability(seed):
+    with test_core.t1(seed=seed) as (bdb, _generator_id):
         bdb.execute('''create generator t1_cond_prob_cc for t1 using
                        crosscat(age numerical, weight numerical,
                            dependent(age, weight));''')
@@ -95,9 +96,9 @@ def test_conditional_probability():
             ' from columns of t1_cond_prob_cc').fetchall()
         assert [(age_is_8_given_weight_is_16,), (0,)] == probs
 
-@flaky(max_runs=2, min_passes=1)
-def test_joint_probability():
-    with test_core.t1() as (bdb, _generator_id):
+@stochastic(max_runs=2, min_passes=1)
+def test_joint_probability(seed):
+    with test_core.t1(seed=seed) as (bdb, _generator_id):
         bdb.execute('initialize 10 models for t1_cc')
         bdb.execute('analyze t1_cc for 10 iterations wait')
         q0 = 'estimate probability of age = 8 by t1_cc'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -267,8 +267,9 @@ t1_rows = [
     (None, 31, 62),
 ]
 
-def t1():
-    return bayesdb_generator(bayesdb(), 't1', 't1_cc', t1_schema, t1_data,
+def t1(*args, **kwargs):
+    return bayesdb_generator(bayesdb(*args, **kwargs), 't1', 't1_cc',
+        t1_schema, t1_data,
         columns=['label CATEGORICAL', 'age NUMERICAL', 'weight NUMERICAL'])
 
 def t1_sub():

--- a/tests/test_stochastic.py
+++ b/tests/test_stochastic.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+#   Copyright (c) 2010-2016, MIT Probabilistic Computing Project
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+
+from stochastic import StochasticError
+from stochastic import stochastic
+
+class Quagga(Exception):
+    pass
+
+@stochastic(max_runs=1, min_passes=1)
+def _test_fail(seed):
+    raise Quagga
+
+@stochastic(max_runs=1, min_passes=1)
+def _test_pass(_seed):
+    pass
+
+passthenfail_counter = 0
+@stochastic(max_runs=2, min_passes=1)
+def _test_passthenfail(seed):
+    global passthenfail_counter
+    passthenfail_counter += 1
+    passthenfail_counter %= 2
+    if passthenfail_counter == 0:
+        raise Quagga
+
+failthenpass_counter = 0
+@stochastic(max_runs=2, min_passes=1)
+def _test_failthenpass(seed):
+    global failthenpass_counter
+    failthenpass_counter += 1
+    failthenpass_counter %= 2
+    if failthenpass_counter == 1:
+        raise Quagga
+
+@stochastic(max_runs=2, min_passes=1)
+def _test_failthenfail(seed):
+    raise Quagga
+
+@stochastic(max_runs=1, min_passes=1)
+def test_stochastic(seed):
+    with pytest.raises(StochasticError):
+        _test_fail()
+    try:
+        _test_fail()
+    except StochasticError as e:
+        assert isinstance(e.excvalue, Quagga)
+    with pytest.raises(Quagga):
+        _test_fail(seed)
+    _test_pass()
+    _test_pass(seed)
+    _test_passthenfail()
+    with pytest.raises(Quagga):
+        _test_passthenfail(seed)
+    _test_failthenpass()
+    with pytest.raises(Quagga):
+        _test_failthenpass(seed)
+    with pytest.raises(StochasticError):
+        _test_failthenfail()
+    with pytest.raises(Quagga):
+        _test_failthenfail(seed)


### PR DESCRIPTION
This does not satisfy the goal I had of quantifying relations between

- the test author's intended minimum probability of success for each test, and
- the test executor's desired significance level and statistical power, or threshold for reporting serious bugs vs missing non-serious bugs, &c. (e.g., to distinguish crash tests from quality tests).

I think that for fixed test executor parameters, any given minimum probability of success induces an optimal choice of max runs / min passes.  But we would eventually like to let the executor vary parameters, e.g. for different Jenkins jobs.  So while this will likely help tracking down stochastic failures for now, there is more to be done to quantify the confidence it should give us in the code's correctness.