### PR TITLE
Correct whitespace in crosscat.py sql

### DIFF
--- a/src/metamodels/crosscat.py
+++ b/src/metamodels/crosscat.py
@@ -46,10 +46,10 @@ crosscat_schema_1 = '''
 INSERT INTO bayesdb_metamodel (name, version) VALUES ('crosscat', 1);
 
 CREATE TABLE bayesdb_crosscat_disttype (
-	name		TEXT NOT NULL PRIMARY KEY,
-	stattype	TEXT NOT NULL REFERENCES bayesdb_stattype(name),
-	default_dist	BOOLEAN NOT NULL,
-	UNIQUE(stattype, default_dist)
+    name		TEXT NOT NULL PRIMARY KEY,
+    stattype	TEXT NOT NULL REFERENCES bayesdb_stattype(name),
+    default_dist	BOOLEAN NOT NULL,
+    UNIQUE(stattype, default_dist)
 );
 
 INSERT INTO bayesdb_crosscat_disttype (name, stattype, default_dist)
@@ -59,40 +59,40 @@ INSERT INTO bayesdb_crosscat_disttype (name, stattype, default_dist)
         ('vonmises', 'cyclic', 1);
 
 CREATE TABLE bayesdb_crosscat_metadata (
-	generator_id	INTEGER NOT NULL PRIMARY KEY
-				REFERENCES bayesdb_generator(id),
-	metadata_json	BLOB NOT NULL
+    generator_id	INTEGER NOT NULL PRIMARY KEY
+                REFERENCES bayesdb_generator(id),
+    metadata_json	BLOB NOT NULL
 );
 
 CREATE TABLE bayesdb_crosscat_column (
-	generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
-	colno		INTEGER NOT NULL CHECK (0 <= colno),
-	cc_colno	INTEGER NOT NULL CHECK (0 <= cc_colno),
-	disttype	TEXT NOT NULL,
-	PRIMARY KEY(generator_id, colno),
-	FOREIGN KEY(generator_id, colno)
-		REFERENCES bayesdb_generator_column(generator_id, colno),
-	UNIQUE(generator_id, cc_colno)
+    generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
+    colno		INTEGER NOT NULL CHECK (0 <= colno),
+    cc_colno	INTEGER NOT NULL CHECK (0 <= cc_colno),
+    disttype	TEXT NOT NULL,
+    PRIMARY KEY(generator_id, colno),
+    FOREIGN KEY(generator_id, colno)
+        REFERENCES bayesdb_generator_column(generator_id, colno),
+    UNIQUE(generator_id, cc_colno)
 );
 
 CREATE TABLE bayesdb_crosscat_column_codemap (
-	generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
-	cc_colno	INTEGER NOT NULL CHECK (0 <= cc_colno),
-	code		INTEGER NOT NULL,
-	value		TEXT NOT NULL,
-	FOREIGN KEY(generator_id, cc_colno)
-		REFERENCES bayesdb_crosscat_column(generator_id, cc_colno),
-	UNIQUE(generator_id, cc_colno, code),
-	UNIQUE(generator_id, cc_colno, value)
+    generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
+    cc_colno	INTEGER NOT NULL CHECK (0 <= cc_colno),
+    code		INTEGER NOT NULL,
+    value		TEXT NOT NULL,
+    FOREIGN KEY(generator_id, cc_colno)
+        REFERENCES bayesdb_crosscat_column(generator_id, cc_colno),
+    UNIQUE(generator_id, cc_colno, code),
+    UNIQUE(generator_id, cc_colno, value)
 );
 
 CREATE TABLE bayesdb_crosscat_theta (
-	generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
-	modelno		INTEGER NOT NULL,
-	theta_json	BLOB NOT NULL,
-	PRIMARY KEY(generator_id, modelno),
-	FOREIGN KEY(generator_id, modelno)
-		REFERENCES bayesdb_generator_model(generator_id, modelno)
+    generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
+    modelno		INTEGER NOT NULL,
+    theta_json	BLOB NOT NULL,
+    PRIMARY KEY(generator_id, modelno),
+    FOREIGN KEY(generator_id, modelno)
+        REFERENCES bayesdb_generator_model(generator_id, modelno)
 );
 '''
 
@@ -100,17 +100,17 @@ crosscat_schema_1to2 = '''
 UPDATE bayesdb_metamodel SET version = 2 WHERE name = 'crosscat';
 
 CREATE TABLE bayesdb_crosscat_diagnostics (
-	generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
-	modelno		INTEGER NOT NULL,
-	checkpoint	INTEGER NOT NULL,
-	logscore	REAL NOT NULL CHECK (logscore <= 0),
-	num_views	INTEGER NOT NULL CHECK (0 < num_views),
-	column_crp_alpha
-			REAL NOT NULL,
-	iterations	INTEGER,	-- Not historically recorded.
-	PRIMARY KEY(generator_id, modelno, checkpoint),
-	FOREIGN KEY(generator_id, modelno)
-		REFERENCES bayesdb_generator_model(generator_id, modelno)
+    generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
+    modelno		INTEGER NOT NULL,
+    checkpoint	INTEGER NOT NULL,
+    logscore	REAL NOT NULL CHECK (logscore <= 0),
+    num_views	INTEGER NOT NULL CHECK (0 < num_views),
+    column_crp_alpha
+            REAL NOT NULL,
+    iterations	INTEGER,	-- Not historically recorded.
+    PRIMARY KEY(generator_id, modelno, checkpoint),
+    FOREIGN KEY(generator_id, modelno)
+        REFERENCES bayesdb_generator_model(generator_id, modelno)
 );
 '''
 
@@ -118,24 +118,24 @@ crosscat_schema_2to3 = '''
 UPDATE bayesdb_metamodel SET version = 3 WHERE name = 'crosscat';
 
 CREATE TABLE bayesdb_crosscat_subsampled (
-	generator_id	INTEGER NOT NULL PRIMARY KEY
-				REFERENCES bayesdb_crosscat_metadata
+    generator_id	INTEGER NOT NULL PRIMARY KEY
+                REFERENCES bayesdb_crosscat_metadata
 );
 
 -- Generator-wide subsample, not per-model.
 CREATE TABLE bayesdb_crosscat_subsample (
-	generator_id    INTEGER NOT NULL
-				REFERENCES bayesdb_crosscat_subsampled,
-	sql_rowid	INTEGER NOT NULL,
-	cc_row_id	INTEGER NOT NULL,
-	PRIMARY KEY(generator_id, sql_rowid ASC),
-	UNIQUE(generator_id, cc_row_id ASC)
-	-- Can't express the desired foreign key constraint,
-	--	FOREIGN KEY(sql_rowid) REFERENCES <table of generator>(rowid),
-	-- for two reasons:
-	--   1. No way for constraint to have data-dependent table.
-	--   2. Can't refer to implicit rowid in sqlite3 constraints.
-	-- So we'll just hope nobody botches it.
+    generator_id    INTEGER NOT NULL
+                REFERENCES bayesdb_crosscat_subsampled,
+    sql_rowid	INTEGER NOT NULL,
+    cc_row_id	INTEGER NOT NULL,
+    PRIMARY KEY(generator_id, sql_rowid ASC),
+    UNIQUE(generator_id, cc_row_id ASC)
+    -- Can't express the desired foreign key constraint,
+    --	FOREIGN KEY(sql_rowid) REFERENCES <table of generator>(rowid),
+    -- for two reasons:
+    --   1. No way for constraint to have data-dependent table.
+    --   2. Can't refer to implicit rowid in sqlite3 constraints.
+    -- So we'll just hope nobody botches it.
 );
 '''
 
@@ -143,18 +143,18 @@ crosscat_schema_3to4 = '''
 UPDATE bayesdb_metamodel SET version = 4 WHERE name = 'crosscat';
 
 CREATE TABLE bayesdb_crosscat_subsample_temp (
-	generator_id    INTEGER NOT NULL
-				REFERENCES bayesdb_crosscat_metadata,
-	sql_rowid	INTEGER NOT NULL,
-	cc_row_id	INTEGER NOT NULL,
-	PRIMARY KEY(generator_id, sql_rowid ASC),
-	UNIQUE(generator_id, cc_row_id ASC)
-	-- Can't express the desired foreign key constraint,
-	--	FOREIGN KEY(sql_rowid) REFERENCES <table of generator>(rowid),
-	-- for two reasons:
-	--   1. No way for constraint to have data-dependent table.
-	--   2. Can't refer to implicit rowid in sqlite3 constraints.
-	-- So we'll just hope nobody botches it.
+    generator_id    INTEGER NOT NULL
+                REFERENCES bayesdb_crosscat_metadata,
+    sql_rowid	INTEGER NOT NULL,
+    cc_row_id	INTEGER NOT NULL,
+    PRIMARY KEY(generator_id, sql_rowid ASC),
+    UNIQUE(generator_id, cc_row_id ASC)
+    -- Can't express the desired foreign key constraint,
+    --	FOREIGN KEY(sql_rowid) REFERENCES <table of generator>(rowid),
+    -- for two reasons:
+    --   1. No way for constraint to have data-dependent table.
+    --   2. Can't refer to implicit rowid in sqlite3 constraints.
+    -- So we'll just hope nobody botches it.
 );
 INSERT INTO bayesdb_crosscat_subsample_temp
     SELECT * FROM bayesdb_crosscat_subsample;
@@ -174,17 +174,17 @@ UPDATE bayesdb_metamodel SET version = 5 WHERE name = 'crosscat';
 ALTER TABLE bayesdb_crosscat_diagnostics
     RENAME TO bayesdb_crosscat_diagnostics_temp;
 CREATE TABLE bayesdb_crosscat_diagnostics (
-	generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
-	modelno		INTEGER NOT NULL,
-	checkpoint	INTEGER NOT NULL,
-	logscore	REAL NOT NULL,
-	num_views	INTEGER NOT NULL CHECK (0 < num_views),
-	column_crp_alpha
-			REAL NOT NULL,
-	iterations	INTEGER,	-- Not historically recorded.
-	PRIMARY KEY(generator_id, modelno, checkpoint),
-	FOREIGN KEY(generator_id, modelno)
-		REFERENCES bayesdb_generator_model(generator_id, modelno)
+    generator_id	INTEGER NOT NULL REFERENCES bayesdb_generator(id),
+    modelno		INTEGER NOT NULL,
+    checkpoint	INTEGER NOT NULL,
+    logscore	REAL NOT NULL,
+    num_views	INTEGER NOT NULL CHECK (0 < num_views),
+    column_crp_alpha
+            REAL NOT NULL,
+    iterations	INTEGER,	-- Not historically recorded.
+    PRIMARY KEY(generator_id, modelno, checkpoint),
+    FOREIGN KEY(generator_id, modelno)
+        REFERENCES bayesdb_generator_model(generator_id, modelno)
 );
 INSERT INTO bayesdb_crosscat_diagnostics
     SELECT * FROM bayesdb_crosscat_diagnostics_temp;


### PR DESCRIPTION
Emacs keeps trying to change this for me, and it's a pain.