### PR TITLE
Distinguish 'single'- and "double"-quoted tokens in CREATE GENERATOR.

### DIFF
--- a/src/grammar.y
+++ b/src/grammar.y
@@ -84,6 +84,8 @@ generator_schema(many)	::= generator_schema(ss) T_COMMA generator_schemum(s).
 generator_schemum(empty)	::= .
 generator_schemum(nonempty)	::= generator_schemum(s) gs_token(t).
 gs_token(comp)			::= T_LROUND generator_schemum(s) T_RROUND.
+gs_token(name)			::= L_NAME(n).
+gs_token(string)		::= L_STRING(s).
 gs_token(prim)			::= ANY(t).
 
 /*

--- a/src/parse.py
+++ b/src/parse.py
@@ -200,8 +200,10 @@ class BQLSemantics(object):
     def p_generator_schema_many(self, ss, s):   ss.append(s); return ss
     def p_generator_schemum_empty(self):        return []
     def p_generator_schemum_nonempty(self, s, t): s.append(t); return s
-    def p_gs_token_prim(self, t):               return t
     def p_gs_token_comp(self, s):               return s
+    def p_gs_token_name(self, n):               return n
+    def p_gs_token_string(self, s):             return ('string', s)
+    def p_gs_token_prim(self, t):               return t
 
     def p_stattype_s(self, name):
         return name

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -510,6 +510,12 @@ def test_trivial_commands():
             ['pqr', 'categorical'],
             ['lmn', 'cyclic'],
         ])]
+    assert parse_bql_string('create generator t_cc for t using crosscat'
+            '''("numerical" "nume""rical", 'qua''gga' categorical)''') == \
+        [ast.CreateGen(False, 't_cc', False, 't', 'crosscat', [
+            ['numerical', 'nume"rical'],
+            [('string', "qua'gga"), 'categorical'],
+        ])]
     assert parse_bql_string('initialize 1 model for t;') == \
         [ast.InitModels(False, 't', 1, None)]
     assert parse_bql_string('initialize 1 model if not exists for t;') == \


### PR DESCRIPTION
No existing users should be affected unless they inadvertently used
single-quotes within a Crosscat schema -- which is something we ought
to detect and reject early anyway.

First small step in preparation for future changes to pass on the
token stream verbatim to the metamodel's schema parser, rather than
munging it into nested lists & strings for convenience.