### PR TITLE
Add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: generic
+
+services:
+  - docker
+
+install:
+  - docker build -f docker/ubuntu1404 .


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

Currently the fails on incorrect Dockerfile

https://travis-ci.org/gliptak/bayeslite/builds/284766554

```
Step 6/8 : RUN ./docker/deps/bayeslite-apsw/pythenv.sh                 ./docker/deps/cgpm/pythenv.sh                 ./docker/deps/crosscat/pythenv.sh                 ./check.sh

 ---> Running in 51c493f5180a

/bin/sh: 1: ./docker/deps/bayeslite-apsw/pythenv.sh: not found

The command '/bin/sh -c ./docker/deps/bayeslite-apsw/pythenv.sh                 ./docker/deps/cgpm/pythenv.sh                 ./docker/deps/crosscat/pythenv.sh                 ./check.sh' returned a non-zero code: 127
```