### PR TITLE
Fix broken Bayeslite build process

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install -q conda=4.6.14 conda-build
 script:
+  # Ensure git describe works.
+  - git describe --dirty --long --match 'v*'
   - export CONDA_PACKAGE_VERSION="${TRAVIS_TAG:-$(date +%Y.%m.%d)}"
   # remove leading v from tags if they exist
   - CONDA_PACKAGE_VERSION="$(sed s/^v// <<<$CONDA_PACKAGE_VERSION)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,6 @@ script:
   # remove leading v from tags if they exist
   - CONDA_PACKAGE_VERSION="$(sed s/^v// <<<$CONDA_PACKAGE_VERSION)"
   # use "edge" channel (latest master) for testing with cgpm/crosscat
-  - conda build . -c probcomp/label/edge -c probcomp -c cidermole -c fritzo -c ursusest
+  - conda build . -c probcomp/label/edge -c probcomp -c cidermole -c fritzo -c ursusest -c anaconda
 after_success:
   - bash conda/upload.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ install:
   - conda config --set always_yes yes --set changeps1 no
   - conda install -q conda=4.6.14 conda-build
 script:
-  # Ensure git describe works.
-  - git describe --dirty --long --match 'v*'
   - export CONDA_PACKAGE_VERSION="${TRAVIS_TAG:-$(date +%Y.%m.%d)}"
   # remove leading v from tags if they exist
   - CONDA_PACKAGE_VERSION="$(sed s/^v// <<<$CONDA_PACKAGE_VERSION)"


### PR DESCRIPTION
I finally found a fix that is not a hack. 

# What does this do?

The Bayeslite build process is based on Travis and Conda. The (main) problem was that the Numpy dependency could not be resolved -- it didn't  resolve it's own dependency on Cython. By adding the channel that is [recommended on Numpy's Anaconda page](https://anaconda.org/anaconda/numpy) used to install Numpy instead of relying to different Conda default channel, we can fix this. 

# Why should we do this?
... because we want to maintain our software?

# How do I test this?

Push something to a branch which is branched off this branch and checkout what happens on Travis.