### PR TITLE
Feature to dump models as JSON

### DIFF
--- a/src/backend.py
+++ b/src/backend.py
@@ -285,3 +285,13 @@ class BayesDB_Backend(object):
         `modelno` is a model number or `None`, meaning all models.
         """
         raise NotImplementedError
+
+    def json_ready_models(self, bdb, population_id, generator_id):
+        """ Return a python data object capturing model information,
+        that's ready to be written in JSON syntax.
+
+        The intent is that this information, combined with the data
+        table (not itself dumped here), should be sufficient to simulate 
+        any of the models.
+        """
+        raise NotImplementedError

--- a/src/backends/cgpm_backend.py
+++ b/src/backends/cgpm_backend.py
@@ -17,7 +17,7 @@
 import itertools
 import json
 import math
-import operator, itertools
+import operator
 
 from collections import Counter
 from collections import defaultdict
@@ -923,75 +923,89 @@ class CGPM_Backend(BayesDB_Backend):
             multiprocess=self._multiprocess,
         )
 
-    # Return python data object that's ready to be written in JSON syntax
-    def json_ready_models(self, bdb, population_name):
-        population_id = core.bayesdb_get_population(bdb, population_name)
-        generators = core.bayesdb_population_generators(
-            bdb, population_id)
-        assert len(generators) == 1
-        generator_id = generators[0]
-        stattypes = {name: stattype for (name, stattype) in
-                     bdb.sql_execute('''
-                         SELECT name, stattype FROM bayesdb_variable
-                         WHERE (generator_id IS NULL OR generator_id = ?)
-                         AND population_id = ?
-                     ''', (generator_id, population_id))}
+    def json_ready_models(self, bdb, population_id, generator_id):
+        stattypes = {
+            name: stattype for (name, stattype) in
+            bdb.sql_execute('''
+                SELECT name, stattype FROM bayesdb_variable
+                WHERE (generator_id IS NULL OR generator_id = ?)
+                AND population_id = ?
+            ''', (generator_id, population_id))
+        }
 
         categories = self._json_ready_categories(bdb, population_id, generator_id)
 
         # Dict mapping colno to variable name
-        names = core.bayesdb_colno_to_variable_names(bdb, population_id, generator_id)
+        name_map = core.bayesdb_colno_to_variable_names(bdb, population_id, generator_id)
         states = self._engine(bdb, generator_id).states
-        model_blobs = [self._json_ready_model(state, names) for state in states]
+        model_blobs = [self._json_ready_model(state, name_map) for state in states]
+        return {
+            "column-statistical-types": stattypes,
+            "categories": categories,
+            "models": model_blobs
+        }
 
-        return {"column-statistical-types": stattypes,
-                "categories": categories,
-                "models": model_blobs}
+    def _json_ready_model(self, state, name_map):
 
-    def _json_ready_model(self, state, names):
-        column_groups = \
-            itertools.groupby(sorted(state.Zv().items()),
-                              key=operator.itemgetter(0))
-        column_partition = \
-            [[names[colno] for (colno, _) in block]
-             for (_, block) in column_groups]
+        # state.Zv() is a column partition given as {colnum: viewnum, ...}
+        column_groups = itertools.groupby(
+            sorted(state.Zv().items()),
+            key=operator.itemgetter(1))
+        column_partition = [
+            [name_map[colno] for (colno, _) in block]
+            for (_, block) in column_groups
+        ]
 
         column_crp_hypers = [view.alpha() for view in state.views.values()]
 
-        # All clusters for all views
-        clusters_for_views = \
-            [[[rowno for (rowno, _) in block]
-              for (_, block) in itertools.groupby(sorted(view.Zr().items()),
-                                                  key=operator.itemgetter(0))]
-             for view in state.views.values()]
+        # All row clusters for all views: e.g. [[[0,1], [2,3,4], [5]], [[0,2,3],[1,4,5]]]
+        # This triple comprehension is tricky so here is some explanation.
+        # view.Zr() is a row partition given as {rownum: clusternum, ...}.
+        # Grouping its items() by cluster number gives one group per cluster,
+        # as (clusternum, [(rownum, clusternum), ...]).
+        # To get a cluster [rownum, rownum, ...] we just strip off the 
+        # cluster number.
+        clusters_for_views = [
+                [
+                    [rowno for (rowno, _) in group]
+                    for (_, group) in itertools.groupby(sorted(view.Zr().items()),
+                        key=operator.itemgetter(1))
+                ]
+                for view in state.views.values()
+            ]
 
         # Each column has a little dict of hyperparameters
-        column_hypers = \
-                {name: state.views[state.Zv()[colno]].dims[colno].hypers
-                 for (colno, name) in names.iteritems()}
+        column_hypers = {
+            name: state.views[state.Zv()[colno]].dims[colno].hypers
+            for (colno, name) in name_map.iteritems()
+        }
 
         # Return dump-able blob
-        return {"column-partition": column_partition,
-                "cluster-crp-hyperparameters": column_crp_hypers,
-                "clusters": clusters_for_views,
-                "column-hypers": column_hypers}
+        return {
+            "column-partition": column_partition,
+            "cluster-crp-hyperparameters": column_crp_hypers,
+            "clusters": clusters_for_views,
+            "column-hypers": column_hypers
+        }
 
     def _json_ready_categories(self, bdb, population_id, generator_id):
-        names = core.bayesdb_colno_to_variable_names(bdb, population_id, generator_id)
-        assert len(names) > 0
+        name_map = core.bayesdb_colno_to_variable_names(bdb, population_id, generator_id)
+        assert len(name_map) > 0
         # All categories for all categorical variables
-        raw_categories = \
-            sorted(bdb.sql_execute('''
-                       SELECT colno, code, value FROM bayesdb_cgpm_category
-                       WHERE generator_id = ?
-                   ''', (generator_id,)))
+        raw_categories = sorted(bdb.sql_execute('''
+            SELECT colno, code, value FROM bayesdb_cgpm_category
+            WHERE generator_id = ?
+            ''', (generator_id,)))
         # Collate categories by variable
-        groups = \
-            {(colno, group) for (colno, group) in 
-                itertools.groupby(raw_categories, key=operator.itemgetter(0))}
-        return {names[colno]:
-                {code: value for(_, code, value) in group}
-                for (colno, group) in groups}
+        groups = {
+            (colno, group)
+            for (colno, group) in 
+            itertools.groupby(raw_categories, key=operator.itemgetter(0))
+        }
+        return {
+            name_map[colno]: {code: value for(_, code, value) in group}
+            for (colno, group) in groups
+        }
 
     def _unique_rowid(self, rowids):
         if len(set(rowids)) != 1:

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -377,6 +377,12 @@ class BayesDB(object):
         """
         return self._sqlite3.changes()
 
+    def dump_models(self, population_name, path):
+        import json
+        with open(path, 'w') as outfile:
+            backend = self.backends['cgpm']
+            json.dump(backend.json_ready_models(self, population_name), outfile, indent=2)
+
 class IBayesDBTracer(object):
     """BayesDB articulated tracing interface.
 

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -379,9 +379,10 @@ class BayesDB(object):
 
     def dump_models(self, population_name, path):
         import json
+        backend = self.backends['cgpm']
+        j = backend.json_ready_models(self, population_name)
         with open(path, 'w') as outfile:
-            backend = self.backends['cgpm']
-            json.dump(backend.json_ready_models(self, population_name), outfile, indent=2)
+            json.dump(j, outfile, indent=2)
 
 class IBayesDBTracer(object):
     """BayesDB articulated tracing interface.

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -378,6 +378,12 @@ class BayesDB(object):
         return self._sqlite3.changes()
 
     def dump_models(self, population_name, path):
+        """Write information about a population's models to a file, as JSON.
+
+        The intent is that this information, combined with the data
+        table (not itself dumped here), should be sufficient to simulate 
+        any of the models.
+        """
         import json
         backend = self.backends['cgpm']
         j = backend.json_ready_models(self, population_name)

--- a/src/bayesdb.py
+++ b/src/bayesdb.py
@@ -377,19 +377,6 @@ class BayesDB(object):
         """
         return self._sqlite3.changes()
 
-    def dump_models(self, population_name, path):
-        """Write information about a population's models to a file, as JSON.
-
-        The intent is that this information, combined with the data
-        table (not itself dumped here), should be sufficient to simulate 
-        any of the models.
-        """
-        import json
-        backend = self.backends['cgpm']
-        j = backend.json_ready_models(self, population_name)
-        with open(path, 'w') as outfile:
-            json.dump(j, outfile, indent=2)
-
 class IBayesDBTracer(object):
     """BayesDB articulated tracing interface.
 

--- a/src/core.py
+++ b/src/core.py
@@ -343,7 +343,7 @@ def bayesdb_variable_numbers(bdb, population_id, generator_id):
     return [colno for (colno,) in cursor]
 
 def bayesdb_variable_name(bdb, population_id, generator_id, colno):
-    """Return the name a population variable."""
+    """Return the name of a population variable."""
     cursor = bdb.sql_execute('''
         SELECT name FROM bayesdb_variable
             WHERE population_id = ?
@@ -351,6 +351,15 @@ def bayesdb_variable_name(bdb, population_id, generator_id, colno):
                 AND colno = ?
     ''', (population_id, generator_id, colno))
     return cursor_value(cursor)
+
+def bayesdb_colno_to_variable_names(bdb, population_id, generator_id):
+    """Return a dictionary that maps column number to variable name in population."""
+    cursor = bdb.sql_execute('''
+        SELECT colno, name FROM bayesdb_variable
+            WHERE population_id = ?
+                AND (generator_id IS NULL OR generator_id = ?)
+    ''', (population_id, generator_id))
+    return {colno: name for (colno, name) in cursor}
 
 def bayesdb_variable_stattype(bdb, population_id, generator_id, colno):
     """Return the statistical type of a population variable."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -91,7 +91,6 @@ def test_json_ready_models():
         assert len(bdb.backends) > 0
         population_name = core.bayesdb_population_name(bdb, pop_id)
         assert core.bayesdb_has_population(bdb, population_name)
-        # with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: ... f.name
         j = bdb.backends['cgpm'].json_ready_models(bdb, population_name)
         for m in j["models"]:
             assert len(m["clusters"]) > 0
@@ -100,9 +99,8 @@ def test_dump_models():
     with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
         import sys
         population_name = core.bayesdb_population_name(bdb, pop_id)
-        fname = '/tmp/dump_models.json'
-        # with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: ... f.name
-        bdb.dump_models(population_name, fname)
+        with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: 
+            bdb.dump_models(population_name, f.name)
 
 class DotdogBackend(bayeslite.backend.BayesDB_Backend):
     def name(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,15 +85,24 @@ def test_bad_db_user_version():
             with bayesdb(pathname=f.name):
                 pass
 
-def test_dump_models():
+def test_json_ready_models():
     with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
         import sys
         assert len(bdb.backends) > 0
         population_name = core.bayesdb_population_name(bdb, pop_id)
         assert core.bayesdb_has_population(bdb, population_name)
-        name = '/tmp/dump_models.json'
         # with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: ... f.name
-        bdb.dump_models(population_name, name)
+        j = bdb.backends['cgpm'].json_ready_models(bdb, population_name)
+        for m in j["models"]:
+            assert len(m["clusters"]) > 0
+
+def test_dump_models():
+    with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
+        import sys
+        population_name = core.bayesdb_population_name(bdb, pop_id)
+        fname = '/tmp/dump_models.json'
+        # with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: ... f.name
+        bdb.dump_models(population_name, fname)
 
 class DotdogBackend(bayeslite.backend.BayesDB_Backend):
     def name(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,6 +85,16 @@ def test_bad_db_user_version():
             with bayesdb(pathname=f.name):
                 pass
 
+def test_dump_models():
+    with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
+        import sys
+        assert len(bdb.backends) > 0
+        population_name = core.bayesdb_population_name(bdb, pop_id)
+        assert core.bayesdb_has_population(bdb, population_name)
+        name = '/tmp/dump_models.json'
+        # with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: ... f.name
+        bdb.dump_models(population_name, name)
+
 class DotdogBackend(bayeslite.backend.BayesDB_Backend):
     def name(self):
         return 'dotdog'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -85,23 +85,6 @@ def test_bad_db_user_version():
             with bayesdb(pathname=f.name):
                 pass
 
-def test_json_ready_models():
-    with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
-        import sys
-        assert len(bdb.backends) > 0
-        population_name = core.bayesdb_population_name(bdb, pop_id)
-        assert core.bayesdb_has_population(bdb, population_name)
-        j = bdb.backends['cgpm'].json_ready_models(bdb, population_name)
-        for m in j["models"]:
-            assert len(m["clusters"]) > 0
-
-def test_dump_models():
-    with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
-        import sys
-        population_name = core.bayesdb_population_name(bdb, pop_id)
-        with tempfile.NamedTemporaryFile(prefix='bayeslite') as f: 
-            bdb.dump_models(population_name, f.name)
-
 class DotdogBackend(bayeslite.backend.BayesDB_Backend):
     def name(self):
         return 'dotdog'
@@ -699,3 +682,23 @@ def test_bayesdb_implicit_population_generator_rename():
         assert not core.bayesdb_has_generator(bdb, population_id, 't')
         assert core.bayesdb_has_generator(bdb, population_id2, 't2')
         assert generator_id2 == generator_id
+
+# Not sure where this test belongs.  It needs a test bdb such as t1(),
+# and something to analyze it, and this test file provides these.
+
+def test_json_ready_models():
+    with analyzed_bayesdb_population(t1(), 1, 1) as (bdb, pop_id, gen_id):
+        assert len(bdb.backends) > 0
+        population_name = core.bayesdb_population_name(bdb, pop_id)
+        assert core.bayesdb_has_population(bdb, population_name)
+        j = bdb.backends['cgpm'].json_ready_models(bdb, pop_id, gen_id)
+        for m in j["models"]:
+            assert len(m["clusters"]) > 0
+
+        # This is handy debugging code (lets you look at the model)
+        # that can be enabled manually when needed
+        if True:
+            import json
+            path = "/tmp/models.json"
+            with open(path, 'w') as outfile:
+                json.dump(j, outfile, indent=2)


### PR DESCRIPTION
Adds a `dump_models` method to the `BayesDB` class that writes JSON describing a population and its models, sufficient for simulation.

(@Schaechtle heads-up.)

(hmm, I guess we should put documentation for the JSON somewhere, but where?)